### PR TITLE
chore: add HPM package for battery monitor

### DIFF
--- a/Battery Monitor/PackageManifest.json
+++ b/Battery Monitor/PackageManifest.json
@@ -1,0 +1,20 @@
+{
+  "packageName": "Simple Battery Monitor",
+  "version": "1.0.0",
+  "releaseNotes": "Initial release",
+  "minimumHEVersion": "2.3",
+  "category": "Utility",
+  "tags": "Tools & Utilities",
+  "author": "Tobey Ljungberg",
+  "apps": [
+    {
+      "id": "d1be6e90-2746-4dee-8e4e-8ce604c059be",
+      "name": "Simple Battery Monitor",
+      "namespace": "tljungber",
+      "location": "https://raw.githubusercontent.com/tobeyljungberg/hubitat/main/Battery%20Monitor/BatteryMonitor.groovy",
+      "required": true,
+      "oauth": false,
+      "primary": false
+    }
+  ]
+}

--- a/HPM/repository.json
+++ b/HPM/repository.json
@@ -31,6 +31,16 @@
         "Tools & Utilities"
       ],
       "id": "8b431248-3747-49ca-b416-f97de136b95f"
+    },
+    {
+      "name": "Simple Battery Monitor",
+      "category": "Utility",
+      "location": "https://raw.githubusercontent.com/tobeyljungberg/hubitat/main/Battery%20Monitor/PackageManifest.json",
+      "description": "Simple battery app.",
+      "tags": [
+        "Tools & Utilities"
+      ],
+      "id": "d1be6e90-2746-4dee-8e4e-8ce604c059be"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add package manifest for Simple Battery Monitor
- register Simple Battery Monitor in HPM repository index

## Testing
- `gradle test` *(fails: PKIX path building failed during dependency resolution)*

------
https://chatgpt.com/codex/tasks/task_b_68c6c06c0d9883209a86ed5ea445aeb4